### PR TITLE
BugFix: 修复当对方发送一个data长度为0的包时rcv_queue会积压的bug

### DIFF
--- a/Kcp/Kcp.cs
+++ b/Kcp/Kcp.cs
@@ -91,7 +91,7 @@ namespace System.Net.Sockets.Kcp
 
                 peekSize = (int)length;
 
-                if (peekSize <= 0)
+                if (peekSize < 0)
                 {
                     return (null, -2);
                 }
@@ -146,7 +146,7 @@ namespace System.Net.Sockets.Kcp
 
                 peekSize = (int)length;
 
-                if (peekSize <= 0)
+                if (peekSize < 0)
                 {
                     return -2;
                 }

--- a/Kcp/KcpIO.cs
+++ b/Kcp/KcpIO.cs
@@ -179,7 +179,7 @@ namespace System.Net.Sockets.Kcp
 
                 peekSize = (int)length;
 
-                if (peekSize <= 0)
+                if (peekSize < 0)
                 {
                     return -2;
                 }


### PR DESCRIPTION
Bug描述：当对方发送一个data长度为0的包时，PeekSize为0，在Recv/TryRecv中直接return，rcv_queue中的第一个包始终无法取出（PeekSize为0），导致积压。可稳定复现。

与原c语言的kcp框架通信发现的，其ikcp_send接口允许发送数据段长度为0的包
int ikcp_send(ikcpcb *kcp, const char *buffer, int len)
{
	IKCPSEG *seg;
	int count, i;
	int sent = 0;

	assert(kcp->mss > 0);
	if (len < 0) return -1;

        ......
}